### PR TITLE
Fix MTIAsyncVideoCompositionRequestHandler crash

### DIFF
--- a/Frameworks/MetalPetal/MTIVideoComposition.swift
+++ b/Frameworks/MetalPetal/MTIVideoComposition.swift
@@ -73,8 +73,8 @@ public class MTIAsyncVideoCompositionRequestHandler {
         public let compositionTime: CMTime
         public let renderSize: CGSize
         
-        public var anySourceImage: MTIImage {
-            return sourceImages.first!.value
+        public var anySourceImage: MTIImage? {
+            return sourceImages.first?.value
         }
     }
     


### PR DESCRIPTION
Crash will happen when sourceImages for Request is empty